### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/nexidian/gocliselect
 go 1.17
 
 require (
-	github.com/buger/goterm v1.0.3
+	github.com/buger/goterm v1.0.4
 	github.com/pkg/term v1.1.0
 )
 
-require golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 // indirect
+require golang.org/x/sys v0.1.0 // indirect


### PR DESCRIPTION
updating to latest versions of dependencies, also forcing the use of a higher version of and indirect dependency due to vulnerabilities in the dependency and the repo not being actively updated

See pending dependabot merge: https://github.com/pkg/term/pull/74 