### PR TITLE
Refactor menu display logic and improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ func main() {
     menu.AddItem("Yellow", "yellow")
     menu.AddItem("Cyan", "cyan")
 
-    choice := menu.Display()
+    choice, err := menu.Display()
+    if err != nil {
+        fmt.Printf("Error: %v\n", err)
+    }
 
     fmt.Printf("Choice: %s\n", choice)
 }

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,21 @@
+package gocliselect
+
+// Terminal control codes
+const (
+	ShowCursor = "\033[?25h"
+	HideCursor = "\033[?25l"
+
+	CursorUpFormat = "\033[%dA" // Requires formatting with number of lines
+
+	KeyUp     = byte(65)
+	KeyDown   = byte(66)
+	KeyEscape = byte(27)
+	KeyEnter  = byte(13)
+)
+
+// NavigationKeys defines a map of specific byte keycodes related to
+// navigation functionality, such as up or down actions.
+var NavigationKeys = map[byte]bool{
+	KeyUp:   true,
+	KeyDown: true,
+}

--- a/example/main.go
+++ b/example/main.go
@@ -14,12 +14,15 @@ func main() {
 	menu.AddItem("Yellow", 1.0)
 	menu.AddItem("Cyan", "cyan")
 
-	result := menu.Display()
+	result, err := menu.Display()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
 
-	if id, ok := result.(int); ok {
-		fmt.Printf("Choice int: %d\n", id)
-	} else if id, ok := result.(string); ok {
-		fmt.Printf("Choice string: %s\n", id)
+	if _, ok := result.(int); ok {
+		fmt.Printf("Selected option: %d\n", result)
+	} else if _, ok := result.(string); ok {
+		fmt.Printf("Selected option: %s\n", result)
 	} else {
 		fmt.Printf("Selected option of unexpected type: %T with value: %v\n", result, result)
 	}


### PR DESCRIPTION
Separated constants into a dedicated file for better organization. Updated `Menu.Display` to return errors when menu items are empty and replaced magic strings with named constants. Modified example and README to reflect the changes and handle potential errors.